### PR TITLE
deviseを使用した認証機能の作成を行いました close #13

### DIFF
--- a/app/controllers/user_authenticates/confirmations_controller.rb
+++ b/app/controllers/user_authenticates/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class UserAuthenticates::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/user_authenticates/omniauth_callbacks_controller.rb
+++ b/app/controllers/user_authenticates/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class UserAuthenticates::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/user_authenticates/passwords_controller.rb
+++ b/app/controllers/user_authenticates/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class UserAuthenticates::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/user_authenticates/registrations_controller.rb
+++ b/app/controllers/user_authenticates/registrations_controller.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class UserAuthenticates::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  # super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/user_authenticates/sessions_controller.rb
+++ b/app/controllers/user_authenticates/sessions_controller.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class UserAuthenticates::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  def create
+    super do |resource|
+      sign_in(:user, resource.user)
+    end
+  end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/user_authenticates/unlocks_controller.rb
+++ b/app/controllers/user_authenticates/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class UserAuthenticates::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,2 +1,3 @@
 class Prefecture < ApplicationRecord
+  has_one :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,6 @@
 class User < ApplicationRecord
-  belongs_to :prefecture
+  has_one :user_authenticates
+  belongs_to :prefecture, optional: true
+
+  devise :authenticatable
 end

--- a/app/models/user_authenticate.rb
+++ b/app/models/user_authenticate.rb
@@ -1,6 +1,15 @@
 class UserAuthenticate < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  belongs_to :user
+  before_validation :set_user
+
+  # Methods
+
+  private
+
+  def set_user
+    self.user = User.new(name: 'no name') if user.nil?
+  end
 end

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,17 +15,23 @@
           投稿
         </button>
       </div>
-      <div class="dropdown dropdown-end ml-3">
-        <button class="btn btn-square btn-ghost h-16 w-20 inline-block">
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="swap-off my-1 text-gohun inline-block w-14 h-14 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
-        </button>
-        <ul class="mt-5 p-2 shadow menu dropdown-content z-[1] bg-gohun rounded-box w-52">
-          <li><a href="#">マイページ</a></li>
-          <li><a href="#">周辺検索</a></li>
-          <li><a href="#">ブックマーク</a></li>
-          <li><a href="#">ログアウト</a></li>
-        </ul>
-      </div>
+      <% if user_authenticate_signed_in? %>
+        <div class="dropdown dropdown-end ml-3">
+          <button class="btn btn-square btn-ghost h-16 w-20 inline-block">
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="swap-off my-1 text-gohun inline-block w-14 h-14 stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+          </button>
+          <ul class="mt-5 p-2 shadow menu dropdown-content z-[1] bg-gohun rounded-box w-52">
+            <li><a href="#">マイページ</a></li>
+            <li><a href="#">周辺検索</a></li>
+            <li><a href="#">ブックマーク</a></li>
+            <li><%=link_to "ログアウト", destroy_user_authenticate_session_path, data: {turbo_method: :delete}%></li>
+          </ul>
+        </div>
+      <%else%>
+        <div class="inline-block">
+          <%= link_to "ログイン", new_user_authenticate_session_path, class: "btn bg-gohun text-sumi px-4 py-1 hover:bg-usuki"%>
+        </div>
+      <%end%>
     </div>
   </div>
 </div>

--- a/app/views/user_authenticates/confirmations/new.html.erb
+++ b/app/views/user_authenticates/confirmations/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend confirmation instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "user_authenticates/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email", value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend confirmation instructions" %>
+  </div>
+<% end %>
+
+<%= render "user_authenticates/shared/links" %>

--- a/app/views/user_authenticates/mailer/confirmation_instructions.html.erb
+++ b/app/views/user_authenticates/mailer/confirmation_instructions.html.erb
@@ -1,0 +1,5 @@
+<p>Welcome <%= @email %>!</p>
+
+<p>You can confirm your account email through the link below:</p>
+
+<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/user_authenticates/mailer/email_changed.html.erb
+++ b/app/views/user_authenticates/mailer/email_changed.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @email %>!</p>
+
+<% if @resource.try(:unconfirmed_email?) %>
+  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+<% else %>
+  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+<% end %>

--- a/app/views/user_authenticates/mailer/password_change.html.erb
+++ b/app/views/user_authenticates/mailer/password_change.html.erb
@@ -1,0 +1,3 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>We're contacting you to notify you that your password has been changed.</p>

--- a/app/views/user_authenticates/mailer/reset_password_instructions.html.erb
+++ b/app/views/user_authenticates/mailer/reset_password_instructions.html.erb
@@ -1,0 +1,8 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+
+<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+
+<p>If you didn't request this, please ignore this email.</p>
+<p>Your password won't change until you access the link above and create a new one.</p>

--- a/app/views/user_authenticates/mailer/unlock_instructions.html.erb
+++ b/app/views/user_authenticates/mailer/unlock_instructions.html.erb
@@ -1,0 +1,7 @@
+<p>Hello <%= @resource.email %>!</p>
+
+<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+
+<p>Click the link below to unlock your account:</p>
+
+<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/user_authenticates/passwords/edit.html.erb
+++ b/app/views/user_authenticates/passwords/edit.html.erb
@@ -1,0 +1,25 @@
+<h2>Change your password</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "user_authenticates/shared/error_messages", resource: resource %>
+  <%= f.hidden_field :reset_password_token %>
+
+  <div class="field">
+    <%= f.label :password, "New password" %><br />
+    <% if @minimum_password_length %>
+      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+    <% end %>
+    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Change my password" %>
+  </div>
+<% end %>
+
+<%= render "user_authenticates/shared/links" %>

--- a/app/views/user_authenticates/passwords/new.html.erb
+++ b/app/views/user_authenticates/passwords/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Forgot your password?</h2>
+
+<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "user_authenticates/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Send me reset password instructions" %>
+  </div>
+<% end %>
+
+<%= render "user_authenticates/shared/links" %>

--- a/app/views/user_authenticates/registrations/edit.html.erb
+++ b/app/views/user_authenticates/registrations/edit.html.erb
@@ -1,0 +1,43 @@
+<h2>Edit <%= resource_name.to_s.humanize %></h2>
+
+<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
+  <%= render "user_authenticates/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+  <% end %>
+
+  <div class="field">
+    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.password_field :password, autocomplete: "new-password" %>
+    <% if @minimum_password_length %>
+      <br />
+      <em><%= @minimum_password_length %> characters minimum</em>
+    <% end %>
+  </div>
+
+  <div class="field">
+    <%= f.label :password_confirmation %><br />
+    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+  </div>
+
+  <div class="field">
+    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.password_field :current_password, autocomplete: "current-password" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Update" %>
+  </div>
+<% end %>
+
+<h3>Cancel my account</h3>
+
+<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+
+<%= link_to "Back", :back %>

--- a/app/views/user_authenticates/registrations/new.html.erb
+++ b/app/views/user_authenticates/registrations/new.html.erb
@@ -1,0 +1,31 @@
+<div class="bg-gohun min-h-screen flex flex-col pt-20">
+  <div class="container max-w-md mx-auto flex-1 flex flex-col justify-center">
+    <div class="bg-base-yellow rounded shadow-md text-sumi w-full border">
+      <div class="flex">
+        <div class="w-1/2 flex justify-center items-center bg-namari border-">
+          <%= link_to "ログイン", new_user_authenticate_session_path, class: "m-4 text-2xl text-center" %>
+        </div>
+        <div class="w-1/2 flex justify-center items-center">
+          <h1 class="m-4 text-2xl text-center">新規登録</h1>
+        </div>
+      </div>
+      <div class="px-6 mt-8">
+        <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
+          <%= render "user_authenticates/shared/error_messages", resource: resource %>
+            <%= f.label :email, "メールアドレス"%>
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "bg-gohun block border border-grey-light w-full p-3 rounded mb-4" %>
+
+            <%= f.label :password, "パスワード"%>
+            <%= f.password_field :password, autocomplete: "new-password", class: "bg-gohun block border border-grey-light w-full p-3 rounded mb-4" %>
+
+            <%= f.label :password_confirmation, "パスワード確認用"%>
+            <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "bg-gohun block border border-grey-light w-full p-3 rounded mb-4" %>
+
+          <div class="w-full text-center py-3 rounded bg-green text-white hover:bg-green-dark focus:outline-none my-6">
+            <%= f.submit "新規登録", class: "bg-gohun block border border-grey-light w-full p-3 rounded mb-5" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/user_authenticates/sessions/new.html.erb
+++ b/app/views/user_authenticates/sessions/new.html.erb
@@ -1,0 +1,37 @@
+<div class="bg-gohun min-h-screen flex flex-col pt-20">
+  <div class="container max-w-md mx-auto flex-1 flex flex-col justify-center">
+    <div class="bg-base-yellow rounded shadow-md text-sumi w-full border">
+      <div class="flex">
+        <div class="w-1/2 flex justify-center items-center">
+          <h1 class="m-4 text-2xl text-center">ログイン</h1>
+        </div>
+        <div class="w-1/2 flex justify-center items-center bg-namari">
+          <%= link_to "新規登録", new_user_authenticate_registration_path, class: "m-4 text-2xl text-center" %>
+        </div>
+
+      </div>
+
+      <div class="px-6 mt-8">
+        <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+          <%= f.label :email, "メールアドレス"%>
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "bg-gohun block border border-grey-light w-full p-3 rounded mb-4" %>
+
+          <%= f.label :password, "パスワード"%>
+          <%= f.password_field :password, autocomplete: "new-password", class: "bg-gohun block border border-grey-light w-full p-3 rounded mb-4" %>
+
+          <% if devise_mapping.rememberable? %>
+            <div class="field flex items-center">
+              <%= f.check_box :remember_me, class: "checkbox checkbox-sm border-opacity-100"%>
+              <%= f.label :remember_me, "ログイン情報を記憶する", class: "ml-1"%>
+            </div>
+          <% end %>
+
+          <div class="w-full text-center py-3 rounded bg-green text-white hover:bg-green-dark focus:outline-none my-6">
+            <%= f.submit "ログイン", class: "bg-gohun block border border-grey-light w-full p-3 rounded mb-5" %>
+          </div>
+  
+        <% end %>
+     </div>
+    </div>
+  </div>
+</div>

--- a/app/views/user_authenticates/shared/_error_messages.html.erb
+++ b/app/views/user_authenticates/shared/_error_messages.html.erb
@@ -1,0 +1,15 @@
+<% if resource.errors.any? %>
+  <div id="error_explanation" data-turbo-cache="false">
+    <h2>
+      <%= I18n.t("errors.messages.not_saved",
+                 count: resource.errors.count,
+                 resource: resource.class.model_name.human.downcase)
+       %>
+    </h2>
+    <ul>
+      <% resource.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/user_authenticates/shared/_links.html.erb
+++ b/app/views/user_authenticates/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end %>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+  <% end %>
+<% end %>

--- a/app/views/user_authenticates/unlocks/new.html.erb
+++ b/app/views/user_authenticates/unlocks/new.html.erb
@@ -1,0 +1,16 @@
+<h2>Resend unlock instructions</h2>
+
+<%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
+  <%= render "user_authenticates/shared/error_messages", resource: resource %>
+
+  <div class="field">
+    <%= f.label :email %><br />
+    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "Resend unlock instructions" %>
+  </div>
+<% end %>
+
+<%= render "user_authenticates/shared/links" %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
-  devise_for :user_authenticates
+  devise_for :user_authenticates, controllers: { registrations: 'user_authenticates/registrations' }
+
   get 'users/show'
   root 'static_pages#top'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20240513010743_devise_create_user_authenticates.rb
+++ b/db/migrate/20240513010743_devise_create_user_authenticates.rb
@@ -3,7 +3,7 @@
 class DeviseCreateUserAuthenticates < ActiveRecord::Migration[7.1]
   def change
     create_table :user_authenticates do |t|
-      t.references :user, foreign_key: true
+      t.references :user, foreign_key: true, null: false
 
       ## Database authenticatable
       t.string :email, null: false, default: ""

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_13_010743) do
   end
 
   create_table "user_authenticates", force: :cascade do |t|
-    t.bigint "user_id"
+    t.bigint "user_id", null: false
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"


### PR DESCRIPTION
## ブランチ名
feature/sign-up-log-in

## 概要
- deviseのregistrationsディレクトリの内容を編集して新規登録画面およびログイン画面の作成を行ってください。
- 新規登録画面を_sign_up.html.erbというパーシャルで作成してください。
- ログイン画面を_login_up.html.erbというパーシャルで作成してください。
- Hotwireを使用して画面遷移なしでログイン機能と新規登録を切り替えてください。

## 目的
- deviseを使用した認証機能の実装を行うため。
- ユーザーが画面遷移なしでログインと新規会員登録の切り替えを行えるようにすることで、ユーザー使いやすくするため。
- パスワードを表示させる機能を実装することで、ユーザーが確認しやすいようにするため。

## 確認ポイント

- [x] deviceで作成されたviewファイルを編集しているか
- [ ] 新規登録画面とログイン画面の切り替えなしが画面遷移なしで行われているか
- [ ] Hotwireを使用しているか
- [ ] 新規登録画面がパーシャルとして作成されているか
- [ ] ログイン画面がパーシャルとして作成されているか
- [x] 新規登録時に以下の動作が正しく行われているか
  - [x] 適切に入力を行った際にDBへの反映が行われているか
  - [ ] 適切に入力を行った際にマイページに遷移しているか
  - [x] 未入力がある場合にエラーが発生しているか
  - [x] 同じメールアドレスを登録しようとした場合にエラーが発生しているか
  - [x] パスワードの入力数が６文字以下の場合にエラーが発生しているか
  - [x] パスワードと確認用のパスワードが違かった場合にエラーが発生しているか
- [x] ログイン時に以下の動作が正しく行われているか
  - [x] 適切に入力を行った際にcurrent_userとして反映がされているか
  - [x] 適切に入力を行った際にトップページに遷移しているか
  - [x] メールアドレスが登録されていない場合にエラーが発生するか
  - [x] メールアドレスとパスワードが一致しない場合にエラーが発生しているか

## 補足
user_authenticatesというモデルを作成し、認証機能の追加を行いました。
新規登録に合わせてuserモデルでのユーザーの作成を行い、user_authenticatesと関連付けを行っております。 現時点ではuser_authenticatesがセッションの管理や認証機能を有しております。
また、認証機能の作成に際してヘッダーの変更等を行っております。

現時点では、マイページの作成を行っていないのでマイページ作成時に画面遷移の処理を追加しようと思っております。
また、hotwireを使用した処理については重要度がそこまで高くないと判断したためISSUEとして切り出して今後、必要性に応じて機能追加を行おうと思っております。