### PR TITLE
新規投稿画面へのgoogle mapの表示 close #18

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,11 +17,9 @@ gem "puma", ">= 5.0"
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
 gem "jsbundling-rails"
 
-# Hotwire's SPA-like page accelerator [https://turbo.hotwired.dev]
-gem "turbo-rails"
-
-# Hotwire's modest JavaScript framework [https://stimulus.hotwired.dev]
+# Hotwire関係のgem
 gem "stimulus-rails"
+gem "turbo-rails"
 
 # Bundle and process CSS [https://github.com/rails/cssbundling-rails]
 gem "cssbundling-rails"
@@ -31,6 +29,9 @@ gem "jbuilder"
 
 # 認証
 gem "devise"
+
+# 環境変数用のgem
+gem "dotenv-rails"
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
@@ -47,7 +48,7 @@ gem "tzinfo-data", platforms: %i[windows jruby]
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
+# active storage関係のgem
 gem "active_storage_validations"
 gem "aws-sdk-s3", require: false
 gem "image_processing", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,10 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    dotenv (3.1.2)
+    dotenv-rails (3.1.2)
+      dotenv (= 3.1.2)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
     ffi (1.16.3)
@@ -299,6 +303,7 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  dotenv-rails
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,11 +1,11 @@
-<div class="flex justify-center items-center min-h-screen pt-20">
+<div class="flex justify-center items-center min-h-screen pt-16">
   <div class="container flex">
     <div class="w-2/5 mr-10 mt-10">
       <h1 class="text-4xl text-center">新しく投稿</h1>
       <%= form_with model: @post, local: true do |f| %>
 
       <%= render "shared/error_messages", object: f.object%>
-        <h1 class="text-center text-2xl mt-10">おすすメーター</1>
+        <h1 class="text-center text-xl mt-6">おすすメーター</1>
         <div class="mt-6 flex justify-center">
           <div class="rating rating-lg">
             <%= f.radio_button :rating, 1, class: 'mask mask-star-2 bg-usuki ' %>
@@ -19,22 +19,45 @@
         <div class="mt-10 flex justify-center">
           <%= f.text_field :title, class:"text-sm bg-gohun border-2 w-4/5 h-10 p-5", placeholder: "ここにおつまみの名称を入れてください"%>
         </div>
-        <div class="mt-5">
+        <div class="mt-6">
           <%= f.label :images do %>
             <i class="fa-solid fa-camera bg-namari p-8 text-gohun"></i>
             <%= f.file_field :images, multiple: true, accept: "image/jpeg,image/jpg,image/png" ,class: "hidden" %>
           <%end%>
         </div>
       
-        <div class="mt-8 flex justify-center">
-          <%= f.text_area :body, class:"text-sm bg-gohun border-2 w-4/5 h-40 p-5", row: "10", placeholder: "おつまみについて入力を行なってください" %>
+        <div class="mt-6 flex justify-center">
+          <%= f.text_area :body, class:"text-sm bg-gohun border-2 w-4/5 h-36 p-5", row: "10", placeholder: "おつまみについて入力を行なってください" %>
         </div>
-        <%= f.submit "投稿",class:"btn btn-wide bg-gohun hover:bg-usuki text-sumi mt-10" %>
+        <%= f.submit "投稿",class:"btn btn-wide bg-gohun hover:bg-usuki text-sumi mt-10 mb-4" %>
       <% end %>
     </div>
-    <div class="w-3/5 h-screen bg-sumi">
+    <div class="w-3/5 mt-3">
+      <div id='map'></div>
     </div>
   </div>
 </div>
 
+<style>
+  #map {
+      height: 100%;
+    }
+  </style>
 
+  <script async>
+    let map
+
+    //初期マップの設定
+    async function initMap(){
+
+      const { AdvancedMarkerElement, PinElement } = await google.maps.importLibrary("marker");
+      const { Map } = await google.maps.importLibrary("maps");
+
+      const map = new Map(document.getElementById("map"),  {
+        zoom: 6,
+        center: { lat: 35.6803997, lng: 139.7690174 },
+        mapId: "971b4d788eb3eff6", // Map ID is required for advanced markers.
+      });
+    }
+  </script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API"]%>&callback=initMap" async defer></script>


### PR DESCRIPTION
## ブランチ名
feature/add-google-maps

## 概要
- 新規投稿画面へgoogle mapの表示を行ってください。
- 現在の時点ではピンを刺したりなどの機能は追加しなくて大丈夫です。
- google mapを使用するためgoogle map APIにて設定を行ってください。
- 環境変数を扱うためのgemとして'dotenv-rails'を使用してください。
- .gitignoreにて.envファイルの設定が行われているか
- 新規投稿画面の右側にgoogle mapが表示されるように設定してください。
- 表示される緯度と経度は日本の緯度と経度に合わせてください。
- google mapが適切に動作するように設定を行なってください。

## 目的 
- ユーザーが適切に購入が可能な場所の特定ができるようにするため
- 今後google map apiを多用していく予定なので、その前の準備を行うため

## 確認ポイント
- [x] 新規投稿画面へgoogle mapが表示されているか
- [x] google map APIにて設定を行なっているか
- [x] 'dotenv-rails'というgemが使用されているか
- [x] .gitignoreに設定をすることで環境変数がgit上にプッシュされていないか
- [x] 新規投稿画面の右側にgoogle mapが表示されているか
- [x] 表示位置として日本が設定されているか
- [x] google mapをスクロールした際に問題なく動作してるか


[![Image from Gyazo](https://i.gyazo.com/553af13f437c546c5887eee88899c074.gif)](https://gyazo.com/553af13f437c546c5887eee88899c074)