### PR TITLE
google mapにマーカー作成機能の追加　close #19

### DIFF
--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -42,22 +42,39 @@
   #map {
       height: 100%;
     }
-  </style>
+</style>
 
-  <script async>
-    let map
+<script async>
+  let map
+  let marker
 
-    //初期マップの設定
-    async function initMap(){
+  //初期マップの設定
+  async function initMap(){
 
-      const { AdvancedMarkerElement, PinElement } = await google.maps.importLibrary("marker");
-      const { Map } = await google.maps.importLibrary("maps");
+    const { AdvancedMarkerElement, PinElement } = await google.maps.importLibrary("marker");
+    const { Map } = await google.maps.importLibrary("maps");
 
-      const map = new Map(document.getElementById("map"),  {
-        zoom: 6,
-        center: { lat: 35.6803997, lng: 139.7690174 },
-        mapId: "971b4d788eb3eff6", // Map ID is required for advanced markers.
+    map = new Map(document.getElementById("map"),  {
+      zoom: 5,
+      center: { lat: 35.6803997, lng: 139.7690174 },
+      mapId: "<%= ENV['GOOGLE_MAP_ID'] %>", // Map ID is required for advanced markers.
+    });
+
+    map.addListener('click', function(e) {
+      getClickLatLng(e.latLng, map);
+    });
+
+    function getClickLatLng(lat_lng, map) {
+      if (marker) {
+      marker.setPosition( lat_lng );
+      } else {
+      marker = new google.maps.Marker({
+        position: lat_lng,
+        map: map
       });
+      }
     }
-  </script>
+    
+  }
+</script>
 <script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API"]%>&callback=initMap" async defer></script>


### PR DESCRIPTION
## ブランチ名
feature/google-map-marker

## 概要
- google mapにてクリックを行なった場所にピンを刺してください。
- ピンを刺せる本数は1本にしてください。
- クリックを2回目行なった場合は1本目のピンを削除して、新しい場所にピンを立ててください。
- ピンを刺した場所が中心に来るようにしてください。

## 目的 
- 今後、ピンを刺した場所の緯度と経度を取得できるようにするため。

## 確認ポイント
- [x] クリックによりピンが作成できているか
- [x] 2回目クリックをした際には1本目のピンが消えているか
- [x] 2回目クリックをした際には新しい位置にピンが立っているか
- [ ] ピンを刺した場所がgoogle mapの中心に来ているか

## 補足

ピンを刺した場所がgoogle mapの中心に来るように計画を立てていましたが、誤ってピンを刺してしまった場合に操作性が悪くなると感じたため、クリック時に中心へ画面遷移を行う実装は行なっておりません。
また、以前使用していたmapIDは仮のものだったので、新規作成を行い.envファイルに値を格納しています。

[![Image from Gyazo](https://i.gyazo.com/39eb8e01cf961e7f5709a118dd34e81d.gif)](https://gyazo.com/39eb8e01cf961e7f5709a118dd34e81d)