### PR TITLE
現在位置取得機能の追加

### DIFF
--- a/app/views/locations/search.html.erb
+++ b/app/views/locations/search.html.erb
@@ -1,0 +1,67 @@
+<div class="flex justify-center items-center min-h-screen pt-16">
+  <div class="container flex">
+    <div class="w-2/5 mr-10 mt-10 h-full">
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+      <h1 class="text-4xl text-center">投稿</h1>
+   </div>
+    <div class="w-3/5 mt-3">
+      <div id='map'></div>
+    </div>
+  </div>
+</div>
+
+<style>
+  #map {
+      height: 100%;
+    }
+</style>
+
+<script async>
+  //初期マップの設定
+  async function initMap(){
+
+    const { AdvancedMarkerElement, PinElement } = await google.maps.importLibrary("marker");
+    const { Map } = await google.maps.importLibrary("maps");
+
+
+    navigator.geolocation.getCurrentPosition(function(position) {
+      let latitude = position.coords.latitude;
+      let longitude = position.coords.longitude;
+
+      let map = new Map(document.getElementById("map"),  {
+        zoom: 12,
+        center: { lat: latitude, lng: longitude },
+        mapId: "<%= ENV['GOOGLE_MAP_ID'] %>", // Map ID is required for advanced markers.
+      });
+
+      let marker = new google.maps.Marker({
+        map : map,
+        position : { lat: latitude, lng: longitude },
+        icon: {
+          fillColor: "#005CAF",                //塗り潰し色
+          fillOpacity: 1.0,                    //塗り潰し透過率
+          path: google.maps.SymbolPath.CIRCLE, //マーカーの形を指定
+          scale: 8,                           //サイズ
+          strokeColor: "#000000",              //枠の色
+          strokeWeight: 1.0                    //枠の透過率
+        },
+      });
+    });
+  }
+</script>
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV["GOOGLE_MAP_API"]%>&callback=initMap" async defer></script>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -17,6 +17,6 @@
 </div>
 <div class="h-[400px]">
   <div class="flex justify-center items-center h-full">
-      <button class="px-10 py-6 border-2 text-3xl bg-usuki">現在位置から周辺を検索</button>
+      <%= link_to "現在位置から周辺を検索",  locations_search_path, class: "px-10 py-6 border-2 text-3xl bg-usuki"%>
   </div>
 </div>


### PR DESCRIPTION
## ブランチ名
feature/google-map-geolocation

## 概要
- google mapを使用して現在位置を取得してください。
- javascriptを使用して現在位置を取得する処理を作成してください。
- localhost:3000/location/searchにアクセスした際、現在位置を表示してください。
- 取得した位置情報を中心にgoogle mapが表示されているようにしてください。 

## 目的 
- 現在位置を取得することで今後、現在位置の周辺にあるおつまみの投稿を表示できるようにするため

## 確認ポイント

- [x] javascriptを使用して現在位置が取得できているか
- [x] 取得した現在位置を中心にgoogle mapが表示されているか
- [x] localhost:3000/location/searchにアクセスした際、現在位置が表示されているか
- [x] 取得した位置を中心にgoogle mapが表示されているか