### PR TITLE
検索機能の追加 close #26

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,15 +27,18 @@ gem 'cssbundling-rails'
 # Build JSON APIs with ease [https://github.com/rails/jbuilder]
 gem 'jbuilder'
 
-# 認証
+# 認証のgem
 gem 'devise'
 
 # 環境変数用のgem
 gem 'dotenv-rails'
 
-# JavaScriptに関するgem
+# JavaScriptのgem
 gem 'geocoder'
 gem 'gon'
+
+# 検索用のgem
+gem 'ransack'
 
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,10 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rake (13.2.1)
+    ransack (4.1.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.9.0)
@@ -325,6 +329,7 @@ DEPENDENCIES
   pry-byebug
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
+  ransack
   selenium-webdriver
   sprockets-rails
   stimulus-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,10 @@
 class ApplicationController < ActionController::Base
+  before_action :set_search
+
+  private
+
+  def set_search
+    @q = Post.ransack(params[:q])
+    @posts = @q.result(distinct: true).order(created_at: 'DESC')
+  end
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,7 +2,9 @@ class PostsController < ApplicationController
   before_action :ensure_correct_user, only: %i[edit update destroy]
 
   def index
-    @posts = Post.all
+    @q = Post.ransack(params[:q])
+    @search = params[:q]
+    @posts = @q.result(distinct: true).order(created_at: :desc)
   end
 
   def show

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,9 +4,16 @@ class Post < ApplicationRecord
   has_many_attached :images
 
   validates :rating, presence: true
-  validates :title, presence: true, length: {maximum: 32}
-  validates :body, length: {maximum: 256}
-  validates :images, content_type: %i[png jpg jpeg], limit: {max: 4}
+  validates :title, presence: true, length: { maximum: 32 }
+  validates :body, length: { maximum: 256 }
+  validates :images, content_type: %i[png jpg jpeg], limit: { max: 4 }
 
   scope :with_coordinates, -> { where.not(latitude: nil, longitude: nil) }
+  def self.ransackable_associations(_auth_object = nil)
+    %w[user prefecture]
+  end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[rating title body local place_id latitude longitude user_id prefecture_id created_at updated_at]
+  end
 end

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,3 +1,6 @@
 class Prefecture < ApplicationRecord
   has_one :user
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at id id_value name updated_at]
+  end
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,7 +1,7 @@
-<div class="flex justify-center min-h-screen pt-20">
+<div class="flex justify-center min-h-screen ">
   <div class="container">
-    <div class="mt-20 text-4xl">
-      <h1>〇〇県〇〇市〇〇〇〇検索結果<h1>
+    <div class="mt-10 text-4xl">
+      <h1><%= @search[:prefecture_name_cont] %>  <%= @search[:title_or_body_cont] %>  検索結果<h1>
     </div>
     <div class="mt-16">
       <a class="text-3xl">合計　<%= @posts.count %>件</a>
@@ -9,7 +9,7 @@
       <a class="ml-3 text-xl">古い順</a>
       <a class="ml-3 text-xl">地元民のおすすめ</a>
     </div>
-    <div class="my-10 flex justify-center">
+    <div class="my-10 flex">
       <div class="flex flex-wrap">
         <% @posts.each do |post|%>
           <%= link_to post_path(post), data: {turbo: false} do%>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,9 +5,18 @@
         <%= image_tag "logo.png", class: "left-0 ml-6 h-16 my-2 w-auto inline-block"%>
       <% end %>
       <div class="inline-block h-full mt-12">
-        <input class="px-2 py-1 bg-gohun text-center" placeholder="都道府県">
-        <input class="px-20 py-1 ml-2 bg-gohun text-center" placeholder="検索">
-        <%= link_to "検索", posts_path, class: "px-2 py-2 bg-gohun text-center"%>
+
+        <%= search_form_for @q, url: posts_path do |f| %>
+
+          <% f.label :prefecture_name_cont %>
+          <%= f.search_field :prefecture_name_cont, class: "px-2 py-1 bg-gohun text-center", placeholder: "都道府県" %>
+
+          <% f.label :title_or_body_cont %>
+          <%= f.search_field :title_or_body_cont, class: "px-20 py-1 ml-2 bg-gohun text-center", placeholder: "フリー検索" %>
+
+          <%= f.submit "検索", class: "px-2 py-1 ml-2 bg-gohun text-center" %>
+        <% end %>
+
       </div>
 
       <div>


### PR DESCRIPTION
## ブランチ名
feature/post-search

## 概要
- 投稿検索機能の追加を行ってください。
- 検索機能を追加する際には'runsack'というgemを使用してください。
- 検索内容は都道府県とおつまみの名称で検索できるように機能の追加をしてください。
- 検索した内容をPostコントローラーに渡し、投稿一覧画面にて表示ができるようにしてください。
- 受け取った検索内容は投稿一覧画面の上部に表示するようにしてください。

## 目的 
- 投稿を地域ごとに表示して、ユーザーが使用しやすくするため

## 確認ポイント

- [x] runsackを使用した実装になっているか
- [x] 都道府県だけで検索が行えるか
- [x] おつまみの名称だけで検索ができるようになっているか
- [x] 都道府県とおつまみの名称どちらも入力し場合に検索ができているか
- [x] 検索した際に投稿一覧画面に遷移しているか
- [x] 検索した際に投稿一覧画面に適切な投稿が表示されているか
- [x] 投稿一覧画面の上部に受け取った検索内容が表示されているか

## 補足
当初予定では市区町村名での検索も検討しておりましたが、MVP時点では不要と考えたため実装は行なっておりません。

[![Image from Gyazo](https://i.gyazo.com/ead11854a9be20b648a13f0690bab4f4.gif)](https://gyazo.com/ead11854a9be20b648a13f0690bab4f4)